### PR TITLE
feat: Updated ref files for colon, lung and melanom

### DIFF
--- a/res/clinicalCancerTypeFiles.txt
+++ b/res/clinicalCancerTypeFiles.txt
@@ -1,10 +1,10 @@
 TYPE=colon
-HOTSPOT=Mutations_Colon_20171219.csv
+HOTSPOT=Mutations_Colon_20250220.csv
 AMPLIFICATION=Amplification_Colon_20160226.txt
 BACKGROUND=Background_Colon_20160226.txt
 
 TYPE=lung
-HOTSPOT=Mutations_Lung_20190211.csv
+HOTSPOT=Mutations_Lung_20250220.csv
 AMPLIFICATION=Amplification_Lung_20160226.txt
 BACKGROUND=Background_Lung_20160226.txt
 
@@ -14,7 +14,7 @@ AMPLIFICATION=false
 BACKGROUND=false
 
 TYPE=melanom
-HOTSPOT=Mutations_Melanom_20230123.csv
+HOTSPOT=Mutations_Melanom_20250220.csv
 AMPLIFICATION=false
 BACKGROUND=false
 


### PR DESCRIPTION
Modifications in order to report non BRAF V600 muts in LC, CRC and melanoma: changed codon 466, 469, 581, 594, 596, 597, 601 to region_all so that RD is reported even if no mut is observed Added 2 genomic coordinates for codon 581 (140453192 & 140453987) so that this codon now is complete